### PR TITLE
allow to provide `namespaces` to the manager CLI

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,7 +35,10 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-var defaultCACertsPath string
+var (
+	defaultCACertsPath string
+	namespaceList      []string
+)
 
 func main() {
 	setupLog := ctrl.Log.WithName("setup")
@@ -56,6 +59,11 @@ func main() {
 			"Setting this value to 0 means no cache.")
 	flag.StringVar(&defaultCACertsPath, "default-ca-certs", "",
 		"The path to a PEM-encoded CA Certificate file to supply as default for OpenStack API requests.")
+	flag.Func("namespace", "A namespace that the controller watches to reconcile ORC objects. "+
+		"Can be specified multiple times.", func(ns string) error {
+		namespaceList = append(namespaceList, ns)
+		return nil
+	})
 
 	zapOpts := zap.Options{
 		Development: true,
@@ -85,6 +93,7 @@ func main() {
 	}
 
 	restConfig := ctrl.GetConfigOrDie()
+	orcOpts.WatchNamespaces = namespaceList
 	err := internalmanager.Run(ctx, &orcOpts, restConfig, scheme.New(), setupLog, log, controllers)
 	if err != nil {
 		setupLog.Error(err, "Error starting manager")


### PR DESCRIPTION
The manager code already has the `watchNamespaces` option and actually
configure it already but there is no way for an user to choose what
namespaces to watch.

For example in Hypershift, CAPO (not deployed by the CAPI operator) runs
in a namespace "capi-provider" and we need ORC to watch for the objects
in that namespace; which without this PR is not possible.

This PR adds `--namespaces` which is a comma-separated list of
namespaces that the controller watches to reconcile ORC objects.
This was taken from CAPO manager code.

(cherry picked from commit 6e0f4a066b7d046b72d08027b98441b12017a0dc)
