### PR TITLE
OSPRH-33246: Add rebasebot post-rebase hook script

### DIFF
--- a/hack/rebasebot-helpers/post-rebase.sh
+++ b/hack/rebasebot-helpers/post-rebase.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This script is run by rebasebot as a post-rebase hook during the rebase of
+# openshift/openstack-resource-controller.
+# It replaces the merge-bot's --run-make flag which ran `make merge-bot`.
+
+set -e
+set -o pipefail
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "post-rebase hook requires a clean worktree" >&2
+    exit 1
+fi
+
+make merge-bot
+
+if [[ -z "$REBASEBOT_GIT_USERNAME" || -z "$REBASEBOT_GIT_EMAIL" ]]; then
+    author_flag=()
+else
+    author_flag=(--author="$REBASEBOT_GIT_USERNAME <$REBASEBOT_GIT_EMAIL>")
+fi
+
+if [[ -n $(git status --porcelain) ]]; then
+    git add -A
+    git commit "${author_flag[@]}" -q -m "UPSTREAM: <drop>: Run make merge-bot"
+fi


### PR DESCRIPTION
Adds `hack/rebasebot-helpers/post-rebase.sh`, a post-rebase hook script for ShiftStacks migration from `merge-bot` to `rebasebot`.

  This replaces the merge-bot `--run-make` flag which ran `make merge-bot` after each rebase. The script runs `make merge-bot` (full-vendoring, generate, generate-openshift) and commits the results, following the pattern used by [cluster-capi-operator](https://github.com/openshift/cluster-capi-operator/tree/main/hack/rebasebot-hook-scripts).

  The rebasebot periodic configs in openshift/release will reference this script via:
  `--post-rebase-hook git:dest/main:hack/rebasebot-helpers/post-rebase.sh`